### PR TITLE
Make tsconfig consistent with jupyterlab's

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,13 @@
     "noImplicitAny": true,
     "noEmitOnError": true,
     "noUnusedLocals": true,
-    "jsx": "react",
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES6",
-    "outDir": "./lib",
-    "lib": ["ES5", "ES2015.Promise", "DOM"],
-    "types": ["node"]
+    "target": "es2015",
+    "lib": ["dom", "es2015"],
+    "types": ["node"],
+    "jsx": "react",
+    "outDir": "./lib"
   },
   "include": ["src/*"]
 }


### PR DESCRIPTION
This doesn't need to go in before the release, but we should keep the tsconfig consistent with jupyterlab's tsconfigbase.