### PR TITLE
Fix Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-celltags
 
-[![Binder](https://beta.mybinder.org/badge.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-celltags/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jupyterlab/jupyterlab-celltags/master?urlpath=lab)
 
 The JupyterLab cell tags extension enables users to easily add, view, and manipulate descriptive tags for notebook cells. The extension includes the functionality to select all cells with a given tag, supporting the performance of any operation on those cells.
 ![](http://g.recordit.co/MxwN6UaFZj.gif)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+name: jupyterlab-celltags
+channels:
+- conda-forge
+dependencies:
+- jupyterlab=1.0
+

--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-jupyter labextension install jupyterlab-celltags
+jupyter labextension install @jupyterlab/celltags


### PR DESCRIPTION
It looks like the Binder link was broken because the extension is now under the `@jupyterlab` organization.

### Changes

- Update to `@jupyterlab/celltags`
- Update to the new Binder log
- Add `environment.yml` to use JupyterLab 1.0